### PR TITLE
chore(npm): preinstall/postinstallフックを既定で無効化

### DIFF
--- a/dot_npmrc
+++ b/dot_npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true


### PR DESCRIPTION
## Summary
- `~/.npmrc` に `ignore-scripts=true` を配置し、`npm install` 時の preinstall / install / postinstall フックの自動実行を既定で無効化
- 2026-04-30 公開の Mini Shai-Hulud サプライチェーンキャンペーン (intercom-client@7.0.4、lightning@2.6.2 / 2.6.3 など) のような preinstall フック経由のクレデンシャル窃取に対する一次防御
- chezmoi 管理 (`dot_npmrc`) としてリポジトリにコミットし、他環境にも `chezmoi apply` で同じ設定を反映できる

## 副作用
- ネイティブモジュールのビルド (`node-gyp`、`sharp`、`bcrypt`、`puppeteer` の Chromium DL 等) が自動で走らなくなる
- 必要なときは個別に解除:
  - `npm install --foreground-scripts` (npm 9+ 推奨)
  - `npm install --ignore-scripts=false`

## Test plan
- [x] `chezmoi apply --force` で `~/.npmrc` が配置されること
- [x] `npm config get ignore-scripts` が `true` を返すこと
- [ ] ネイティブビルドが必要なパッケージが `--foreground-scripts` で意図どおり動くこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)