### PR TITLE
fix(ghostty): 行間が詰まって読みにくいのでadjust-cell-heightを12%に

### DIFF
--- a/private_dot_config/ghostty/config
+++ b/private_dot_config/ghostty/config
@@ -18,7 +18,7 @@ font-thicken = false
 alpha-blending = linear
 
 adjust-cell-width = -1
-adjust-cell-height = 2
+adjust-cell-height = 12%
 
 # macOS
 macos-titlebar-style = tabs


### PR DESCRIPTION
## Summary
- neovimでバッファを開くと行間が詰まって読みにくいため、Ghosttyの `adjust-cell-height` を固定 `2`(px) からフォントサイズ比例の `12%` に変更
- セル高がフォントサイズに追従するようになり、可読性が向上

## Test plan
- [ ] `chezmoi apply --force` で `~/.config/ghostty/config` に反映されること
- [ ] Ghostty設定リロード（`Cmd+Shift+,`）後、neovimの行間が広がって読みやすくなること