### PR TITLE
chore(codex): 設定フラグとsandbox運用を整理

### DIFF
--- a/private_dot_codex/config.toml
+++ b/private_dot_codex/config.toml
@@ -1,7 +1,7 @@
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "xhigh" # モデルの推論努力（思考の深さ）
 model_verbosity = "medium"       # 詳細な応答の冗長さ（情報量の多さ）
-sandbox_mode = "danger-full-access" # sandboxなし（ローカル開発用）
+sandbox_mode = "workspace-write" # 通常は作業ディレクトリ内だけ書き込み可
 
 # コマンド実行を承認するかどうかをプロンプトで確認すべきタイミング
 # - untrusted: 「信頼済み」でないコマンド（危険操作など）は実行前に都度承認を求め
@@ -25,8 +25,7 @@ include_only = ["PATH", "HOME", "USER"]
 exclude = ["AWS_*", "AZURE_*", "*TOKEN*", "*SECRET*", "*KEY*"]
 
 [features]
-collaboration_modes = true
-codex_hooks = true
+hooks = true
 
 
 # [mcp_servers.serena]


### PR DESCRIPTION
## 概要
- `codex_hooks` と `collaboration_modes` を整理して現行の `hooks` に統一
- デフォルトの `sandbox_mode` を `workspace-write` に戻す
- `model` を `gpt-5.5` に更新

## 背景
Codex CLI の現行 feature 状態に合わせて deprecated / removed な設定を片付けつつ、通常運用ではフル権限を常時持たせない形に寄せました。
これで普段は `approval_policy = "never"` のまま都度承認を避けつつ、`danger-full-access` は必要時だけ起動オプションで付与できます。

## 確認
- 設定ファイルのみの変更のためテストは未実施
- `codex --help` は変更後も通過済み