### PR TITLE
fix(ghostty): adjust-cell-heightを20%にして行間を広げる

### DIFF
--- a/private_dot_config/ghostty/config
+++ b/private_dot_config/ghostty/config
@@ -18,7 +18,7 @@ font-thicken = false
 alpha-blending = linear
 
 adjust-cell-width = -1
-adjust-cell-height = 12%
+adjust-cell-height = 20%
 
 # macOS
 macos-titlebar-style = tabs


### PR DESCRIPTION
## Summary
- Ghostty `adjust-cell-height` を `12%` → `20%` に拡大
- neovimでの行間をZedエディタの広さ(comfortable/黄金比1.618)に近づけ、可読性を改善

## Test plan
- [ ] `chezmoi apply --force` で `~/.config/ghostty/config` に反映されること
- [ ] Ghostty設定リロード(`Cmd+Shift+,`)後、行間が広がって読みやすいこと