### PR TITLE
fix(nvim): mason-lspconfigのautomatic_enableを無効化

### DIFF
--- a/private_dot_config/nvim/lua/lsp/init.lua
+++ b/private_dot_config/nvim/lua/lsp/init.lua
@@ -20,9 +20,12 @@ local ls_names = {
 }
 
 -- Setup Mason-lspconfig
+-- automatic_enable = false: ls_names を唯一の権威にする
+-- (true だと Mason インストール済みの全LSPが自動有効化され、ls_names から外しても起動してしまう)
 require("mason-lspconfig").setup({
   automatic_installation = true,
   ensure_installed = ls_names,
+  automatic_enable = false,
 })
 
 vim.lsp.enable(ls_names)


### PR DESCRIPTION
## Summary
- Copilot削除後も `copilot` LSPが起動し続ける問題の修正
- 原因: `mason-lspconfig` v2 は `automatic_enable = true` が既定で、`ls_names` を無視して **Masonインストール済みの全LSPを自動有効化**する。`copilot-language-server` がMasonに残存していたため起動していた
- `automatic_enable = false` にし、既存の明示的な `vim.lsp.enable(ls_names)` を唯一の権威に

## 補足（このPR外・手元で実施済み）
- Masonの `copilot-language-server` パッケージを削除（`~/.local/share/nvim/mason/`）
- 残: nvimで `:Lazy clean`（旧copilot/sidekickプラグインのディスク掃除）

## Test plan
- [ ] nvim起動でcopilot LSPが起動しないこと（`:LspInfo` / `:checkhealth lsp`）
- [ ] ls_names記載のLSP（lua_ls/basedpyright/ruff/ts_ls等）は従来通り起動すること