### PR TITLE
feat(nvim): md-render.nvimでターミナル内markdownプレビューを追加

### DIFF
--- a/private_dot_config/mise/config.toml
+++ b/private_dot_config/mise/config.toml
@@ -19,7 +19,7 @@ delta = "latest"
 fzf = "latest"
 lazygit = "latest"
 gh = "latest"
-neovim = "0.11"
+neovim = "0.12"
 usage = "latest"
 ghq = "latest"
 

--- a/private_dot_config/nvim/lua/plugins/tools.lua
+++ b/private_dot_config/nvim/lua/plugins/tools.lua
@@ -92,6 +92,21 @@ return {
     },
   },
 
+  -- Markdown preview in terminal (Kitty graphics)
+  {
+    "delphinus/md-render.nvim",
+    version = "*",
+    ft = { "markdown" },
+    dependencies = {
+      { "nvim-tree/nvim-web-devicons", version = "*" },
+      { "delphinus/budoux.lua", version = "*" },
+    },
+    keys = {
+      { "<leader>mr", "<Plug>(md-render-preview)", desc = "Markdown render (float toggle)" },
+      { "<leader>mR", "<Plug>(md-render-preview-tab)", desc = "Markdown render (tab toggle)" },
+    },
+  },
+
   -- Typst preview in browser
   {
     "chomosuke/typst-preview.nvim",


### PR DESCRIPTION
## 概要
`delphinus/md-render.nvim` を導入し、ターミナル内で完結する markdown プレビューを追加する。

## 背景・経緯
- ターミナルネイティブな markdown プレビュー手段が欲しかった。md-render.nvim は Kitty graphics protocol を使い、表・コードハイライト・Mermaid・画像などをターミナル内に描画する。
- 既存の `iamcco/markdown-preview.nvim`(ブラウザ版)は削除せず**併設**。ターミナル内 / ブラウザを用途で使い分ける。
- md-render.nvim は **Neovim 0.12+ が必須**(`vim.api.nvim_ui_send` を使用)。現行は 0.11.7 だったため、mise の neovim pin を `0.11` → `0.12` に更新し 0.12.2 を導入した。
  - 補足: chezmoi 管理外の `~/mise.toml` も neovim を pin しており global config を上書きしていたため、そちらも `0.12` に更新済み(本 PR の差分には含まれない)。mise 設定の重複は別途整理したい。

## 変更点
- `private_dot_config/mise/config.toml`: neovim `0.11` → `0.12`
- `private_dot_config/nvim/lua/plugins/tools.lua`: md-render.nvim の lazy.nvim spec を追加
  - deps: `nvim-web-devicons`(導入済), `budoux.lua`(日本語の文節改行)
  - `ft = markdown` で遅延ロード
  - keymap: `<leader>mr`(float トグル)/ `<leader>mR`(tab トグル)。`<leader>mp` `<leader>ms` は既存プラグインと衝突するため別名前空間にした

## 既知の制約
- **tmux 内では画像が描画されない。** md-render は Kitty graphics の APC エスケープを `nvim_ui_send` で素のまま送出しており、tmux 向けの DCS パススルーラップを実装していない(`allow-passthrough on` だけでは不十分)。
  - テキスト / 表 / コードハイライト / Mermaid は tmux 内でも描画される。
  - 画像を見る場合は tmux を介さず端末(Ghostty)直で nvim を起動するか、併設の `:MarkdownPreview`(ブラウザ版)を使う。

## Test plan
- [x] `mise install` で Neovim 0.12.2 を導入、`nvim --version` で確認
- [x] `chezmoi apply --force` で反映、ターゲット差分なし
- [x] `tools.lua` の Lua パースチェック通過
- [ ] nvim 起動 → `:Lazy sync` で md-render.nvim / budoux.lua 取得 → markdown で描画確認