### PR TITLE
fix(ghostty): 行間をadjust-cell-height 25%に微調整

### DIFF
--- a/private_dot_config/ghostty/config
+++ b/private_dot_config/ghostty/config
@@ -18,7 +18,7 @@ font-thicken = false
 alpha-blending = linear
 
 adjust-cell-width = -1
-adjust-cell-height = 20%
+adjust-cell-height = 25%
 
 # macOS
 macos-titlebar-style = tabs


### PR DESCRIPTION
## Summary
- ghostty の `adjust-cell-height` を 20% → 25% に変更し、行間をやや広げる

🤖 Generated with [Claude Code](https://claude.com/claude-code)