### PR TITLE
feat(theme): Rose Pine Dawn 採用と関連ツールの配色統一

### DIFF
--- a/private_dot_config/ghostty/config
+++ b/private_dot_config/ghostty/config
@@ -1,5 +1,11 @@
-theme = Rose Pine
-background = #0a0a12
+theme = Rose Pine Dawn
+
+# Override blue (foam → pine) for better contrast on Dawn cream background
+palette = 4=#286983
+palette = 12=#286983
+
+# Override bright black (muted → subtle) for readable dim text (Claude Code reasoning 等)
+palette = 8=#797593
 
 font-family = UDEV Gothic 35NF
 font-family = HackGen Console NFJ

--- a/private_dot_config/lsd/colors.yaml
+++ b/private_dot_config/lsd/colors.yaml
@@ -1,0 +1,31 @@
+user: "#575279"
+group: "#797593"
+
+permission:
+  read: "#286983"
+  write: "#ea9d34"
+  exec: "#b4637a"
+  exec-sticky: "#907aa9"
+  no-access: "#9893a5"
+  octal: "#575279"
+
+date:
+  hour-old: "#286983"
+  day-old: "#907aa9"
+  older: "#797593"
+
+size:
+  none: "#9893a5"
+  small: "#286983"
+  medium: "#907aa9"
+  large: "#b4637a"
+
+inode:
+  valid: "#56949f"
+  invalid: "#9893a5"
+
+links:
+  valid: "#286983"
+  invalid: "#b4637a"
+
+tree-edge: "#9893a5"

--- a/private_dot_config/lsd/config.yaml
+++ b/private_dot_config/lsd/config.yaml
@@ -1,0 +1,3 @@
+color:
+  when: auto
+  theme: custom

--- a/private_dot_config/starship.toml
+++ b/private_dot_config/starship.toml
@@ -1,29 +1,84 @@
 "$schema" = 'https://starship.rs/config-schema.json'
 
+palette = "rose_pine_dawn"
+
 format = """
-[](fg:#a3aed2)\
+[](fg:pine)\
 $os\
 $username\
 $hostname\
-[](bg:#769ff0 fg:#a3aed2)\
+[](bg:iris fg:pine)\
 $directory\
-[](fg:#769ff0 bg:#394260)\
+[](fg:iris bg:hl_med)\
 $git_branch\
 $git_status\
-[](fg:#394260 bg:#212736)\
+[](fg:hl_med bg:hl_low)\
 $nix_shell\
 $nodejs\
 $rust\
 $golang\
 $php\
 $python\
-[](fg:#212736 bg:#1d2230)\
-$time\
-[](fg:#1d2230)\
+[](fg:hl_low)\
+ $time\
 \n$character"""
 
+[palettes.rose_pine_dawn]
+base       = "#faf4ed"
+surface    = "#fffaf3"
+overlay    = "#f2e9e1"
+muted      = "#9893a5"
+subtle     = "#797593"
+text       = "#575279"
+love       = "#b4637a"
+gold       = "#ea9d34"
+rose       = "#d7827e"
+pine       = "#286983"
+foam       = "#56949f"
+iris       = "#907aa9"
+hl_low     = "#f4ede8"
+hl_med     = "#dfdad9"
+hl_high    = "#cecacd"
+
+[os]
+disabled = false
+style = "fg:base bg:pine"
+format = "[ $symbol ]($style)"
+
+[os.symbols]
+Windows = "󰍲"
+Ubuntu = ""
+SUSE = ""
+Raspbian = "󰐿"
+Mint = "󰣭"
+Macos = "󰀵"
+Manjaro = ""
+Linux = "󰌽"
+Gentoo = "󰣨"
+Fedora = "󰣛"
+Alpine = ""
+Amazon = ""
+Android = ""
+Arch = "󰣇"
+Artix = "󰣇"
+CentOS = ""
+Debian = "󰣚"
+Redhat = "󱄛"
+RedHatEnterprise = "󱄛"
+
+[username]
+show_always = true
+style_user = "fg:base bg:pine"
+style_root = "fg:love bg:pine bold"
+format = "[$user@]($style)"
+
+[hostname]
+ssh_only = false
+style = "fg:base bg:pine"
+format = "[$hostname ]($style)"
+
 [directory]
-style = "fg:#e3e5e5 bg:#769ff0"
+style = "fg:base bg:iris bold"
 format = "[ $path ]($style)"
 truncation_length = 3
 truncation_symbol = "…/"
@@ -35,83 +90,46 @@ truncation_symbol = "…/"
 "Pictures" = " "
 
 [git_branch]
-symbol = ""
-style = "bg:#394260"
-format = '[[ $symbol $branch ](fg:#769ff0 bg:#394260)]($style)'
+symbol = ""
+style = "bg:hl_med"
+format = '[[ $symbol ](fg:love bg:hl_med bold)[$branch ](fg:text bg:hl_med)]($style)'
 
 [git_status]
-style = "bg:#394260"
-format = '[[($all_status$ahead_behind )](fg:#769ff0 bg:#394260)]($style)'
+style = "bg:hl_med"
+format = '[[($all_status$ahead_behind )](fg:love bg:hl_med)]($style)'
 
 [nix_shell]
 symbol = ""
-style = "bg:#212736"
-format = '[[ $symbol $state ](fg:#7ebae4 bg:#212736)]($style)'
+style = "bg:hl_low"
+format = '[[ $symbol $state ](fg:pine bg:hl_low)]($style)'
 
 [nodejs]
-symbol = ""
-style = "bg:#212736"
-format = '[[ $symbol ($version) ](fg:#769ff0 bg:#212736)]($style)'
+symbol = ""
+style = "bg:hl_low"
+format = '[[ $symbol ($version) ](fg:pine bg:hl_low)]($style)'
 
 [rust]
-symbol = ""
-style = "bg:#212736"
-format = '[[ $symbol ($version) ](fg:#769ff0 bg:#212736)]($style)'
+symbol = ""
+style = "bg:hl_low"
+format = '[[ $symbol ($version) ](fg:pine bg:hl_low)]($style)'
 
 [golang]
-symbol = ""
-style = "bg:#212736"
-format = '[[ $symbol ($version) ](fg:#769ff0 bg:#212736)]($style)'
+symbol = ""
+style = "bg:hl_low"
+format = '[[ $symbol ($version) ](fg:pine bg:hl_low)]($style)'
 
 [php]
-symbol = ""
-style = "bg:#212736"
-format = '[[ $symbol ($version) ](fg:#769ff0 bg:#212736)]($style)'
+symbol = ""
+style = "bg:hl_low"
+format = '[[ $symbol ($version) ](fg:pine bg:hl_low)]($style)'
 
 [python]
-symbol = ""
-style = "bg:#212736"
-format = '[[ $symbol ($version) ](fg:#769ff0 bg:#212736)]($style)'
+symbol = ""
+style = "bg:hl_low"
+format = '[[ $symbol ($version) ](fg:pine bg:hl_low)]($style)'
 
 [time]
 disabled = false
 time_format = "%R"
-style = "bg:#1d2230"
-format = '[[ $time ](fg:#a0a9cb bg:#1d2230)]($style)'
-
-[os]
-disabled = false
-style = "bg:#a3aed2 fg:#090c0c"
-format = "[ $symbol ]($style)"
-
-[os.symbols]
-Windows = "󰍲"
-Ubuntu = ""
-SUSE = ""
-Raspbian = "󰐿"
-Mint = "󰣭"
-Macos = "󰀵"
-Manjaro = ""
-Linux = "󰌽"
-Gentoo = "󰣨"
-Fedora = "󰣛"
-Alpine = ""
-Amazon = ""
-Android = ""
-Arch = "󰣇"
-Artix = "󰣇"
-CentOS = ""
-Debian = "󰣚"
-Redhat = "󱄛"
-RedHatEnterprise = "󱄛"
-
-[username]
-show_always = true
-style_user = "bg:#a3aed2 fg:#090c0c"
-style_root = "bg:#a3aed2 fg:#ff0000 bold"
-format = "[$user@]($style)"
-
-[hostname]
-ssh_only = false
-style = "bg:#a3aed2 fg:#090c0c"
-format = "[$hostname ]($style)"
+style = "fg:subtle"
+format = '[ $time]($style)'


### PR DESCRIPTION
## Summary
ターミナル周りを Rose Pine Dawn（light）テーマで揃え、cream 背景での視認性を改善。

## 変更
- **ghostty**: \`theme = Rose Pine\` → \`Rose Pine Dawn\`、palette 4/12 (blue: foam→pine)、palette 8 (dim: muted→subtle)
- **starship**: \`[palettes.rose_pine_dawn]\` を定義、chip グラデを pine → iris → highlight-high/med/low に再構成、git chip は love+bold アイコン + text fg、time chip 廃止、powerline 境界 維持
- **lsd**: \`config.yaml\` (\`theme: custom\`) + \`colors.yaml\` を新規。既定の薄黄 #ffffaf 等を rose-pine 系の読める色に置換

## Test plan
- [ ] Ghostty 再起動で blue が pine（深青）、dim 文字（reasoning 等）が読める
- [ ] zsh で新 starship プロンプト（chip + powerline 境界 + AA contrast）
- [ ] \`ll\` で薄黄が消え rose-pine 系の色になっている

🤖 Generated with [Claude Code](https://claude.com/claude-code)