### PR TITLE
chore(bootstrap): mise version 固定と install スクリプトの安全化

### DIFF
--- a/run_once_before_20-install-tools.sh.tmpl
+++ b/run_once_before_20-install-tools.sh.tmpl
@@ -3,18 +3,22 @@ set -eu
 
 mkdir -p "${HOME}/.local/bin"
 
-# mise
+# mise（バージョン固定）
+MISE_VERSION="v2026.5.13"
 if ! command -v mise &> /dev/null; then
-  echo "==> Installing mise..."
-  curl --proto '=https' --tlsv1.2 -sSf https://mise.run | sh
+  echo "==> Installing mise ${MISE_VERSION}..."
+  installer="$(mktemp)"
+  curl --proto '=https' --tlsv1.2 -sSf -o "${installer}" https://mise.run
+  MISE_VERSION="${MISE_VERSION}" sh "${installer}"
   export PATH="${HOME}/.local/bin:${PATH}"
 fi
 
 # sheldon (公式スクリプト)
 if ! command -v sheldon &> /dev/null; then
   echo "==> Installing sheldon..."
-  curl --proto '=https' -fLsS https://rossmacarthur.github.io/install/crate.sh \
-    | bash -s -- --repo rossmacarthur/sheldon --to ~/.local/bin
+  installer="$(mktemp)"
+  curl --proto '=https' -fLsS -o "${installer}" https://rossmacarthur.github.io/install/crate.sh
+  bash "${installer}" --repo rossmacarthur/sheldon --to ~/.local/bin
 fi
 
 # tmux plugin manager


### PR DESCRIPTION
## Summary
- \`MISE_VERSION=v2026.5.13\` で固定して再現性を確保
- \`mise\` / \`sheldon\` の install スクリプトを \`curl | sh\` パイプから \`mktemp\` でファイルに保存してから実行する形に変更

## なぜ
- mise の自動更新で broke することがある（pnpm v11 のアセット名変更で 9 ヶ月分古い mise が失敗するなど）→ pin で固定して再現性を確保
- パイプ実行は失敗時の挙動が読みづらく、デバッグ時に再実行しづらい → mktemp で 2 段階に

## Test plan
- [ ] 新規環境（mise 未インストール）で run_once が実行されると v2026.5.13 が入る
- [ ] 既存環境（mise あり）では \`command -v mise\` ガードでスキップ（既存挙動）

🤖 Generated with [Claude Code](https://claude.com/claude-code)