### PR TITLE
chore(tmux): TPMプラグイン読み込みを無効化

### DIFF
--- a/dot_tmux.conf
+++ b/dot_tmux.conf
@@ -101,8 +101,8 @@ bind-key C-p paste-buffer
 
 # List of plugins
 # Install plugins with: prefix + I
-set -g @plugin 'tmux-plugins/tpm'
-set -g @plugin 'arcticicestudio/nord-tmux'
-
-# Initialize TMUX plugin manager (keep this line at the very bottom)
-run '~/.tmux/plugins/tpm/tpm'
+# set -g @plugin 'tmux-plugins/tpm'
+# set -g @plugin 'arcticicestudio/nord-tmux'
+#
+# # Initialize TMUX plugin manager (keep this line at the very bottom)
+# run '~/.tmux/plugins/tpm/tpm'


### PR DESCRIPTION
## Summary
  - disable tmux TPM plugin loading by commenting out the plugin setup

  ## Test
  - not run (tmux config change only)