### PR TITLE
chore(mise): python 3.12 + neovim aqua バックエンド明示

### DIFF
--- a/private_dot_config/mise/config.toml
+++ b/private_dot_config/mise/config.toml
@@ -1,7 +1,7 @@
 [tools]
 # -- Languages
 node = "24"
-python = "3.11"
+python = "3.12"
 go = "latest"
 deno = "latest"
 # julia = "latest"
@@ -19,7 +19,7 @@ delta = "latest"
 fzf = "latest"
 lazygit = "latest"
 gh = "latest"
-neovim = "0.12"
+"aqua:neovim/neovim" = "0.12"
 usage = "latest"
 ghq = "latest"
 


### PR DESCRIPTION
## Summary
- \`python\`: \`3.11\` → \`3.12\`
- \`neovim\`: 暗黙バックエンド → \`"aqua:neovim/neovim"\` を明示

## なぜ
- python は 3.12 が最新stable
- neovim は古い vfox バックエンド (\`vfox:mise-plugins/vfox-neovim\`) を mise が registry 解決でこける問題があり、\`no aqua-registry found for mise-plugins/vfox-neovim\` という警告がコマンド実行ごとに出ていた → aqua バックエンド明示でレジストリ走査自体をスキップして抑止

## Test plan
- [ ] \`mise install\` が python 3.12 / neovim を取得できる
- [ ] シェル起動時の vfox-neovim 警告が出なくなる

🤖 Generated with [Claude Code](https://claude.com/claude-code)