### PR TITLE
chore(git): tasks/ を .gitignore に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ node_modules/
 *.key
 *secret*
 credentials*
+
+# local working notes (Claude Code 等の作業メモ)
+tasks/


### PR DESCRIPTION
## Summary
- \`tasks/\` を \`.gitignore\` に追加
- Claude Code 等の作業メモ用ローカルディレクトリが \`git status\` に出続けるのを抑止

🤖 Generated with [Claude Code](https://claude.com/claude-code)