### PR TITLE
chore(zsh): GITHUB_TOKEN を gh から export (mise rate limit 回避)

### DIFF
--- a/dot_zshrc
+++ b/dot_zshrc
@@ -40,6 +40,11 @@ fi
 source "$_sheldon_cache"
 unset _sheldon_cache _sheldon_toml
 
+# --- GITHUB_TOKEN (gh CLI から取得 / mise の GitHub API rate limit 回避用)
+if command -v gh &>/dev/null; then
+  export GITHUB_TOKEN="$(gh auth token 2>/dev/null)"
+fi
+
 # --- mise（shimsのみ、activate不要）
 # PATHに既に追加済み
 


### PR DESCRIPTION
## Summary
- \`dot_zshrc\` で \`gh auth token\` の結果を \`GITHUB_TOKEN\` として export
- mise の aqua バックエンド (例: \`aqua:neovim/neovim\`) が GitHub API レートリミットで失敗するのを抑止

## なぜ
\`mise install aqua:neovim/neovim@0.12\` 実行時に以下が出ていた:
\`\`\`
mise WARN  GitHub rate limit exceeded.
mise WARN  No GitHub token was found, so mise is making unauthenticated requests...
mise ERROR Failed to install ... HTTP status client error (403 Forbidden)
\`\`\`
gh CLI で認証済みなのに mise が token を自動取得しないため、明示的に export する。

## Test plan
- [ ] 新規シェルで \`echo \${GITHUB_TOKEN:0:7}\` が \`gho_xxx\` 系を返す
- [ ] \`mise install aqua:neovim/neovim@0.12\` が rate limit 警告なしで成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)