### PR TITLE
style(theme): dim text の色を #524d70 に統一して可読性向上

### DIFF
--- a/private_dot_config/ghostty/config
+++ b/private_dot_config/ghostty/config
@@ -4,8 +4,8 @@ theme = Rose Pine Dawn
 palette = 4=#286983
 palette = 12=#286983
 
-# Override bright black (muted → subtle) for readable dim text (Claude Code reasoning 等)
-palette = 8=#797593
+# Override bright black for readable dim text (Claude Code reasoning 等)
+palette = 8=#524d70
 
 font-family = UDEV Gothic 35NF
 font-family = HackGen Console NFJ

--- a/private_dot_config/lsd/colors.yaml
+++ b/private_dot_config/lsd/colors.yaml
@@ -1,31 +1,31 @@
-user: "#575279"
-group: "#797593"
+user: "#524d70"
+group: "#524d70"
 
 permission:
   read: "#286983"
   write: "#ea9d34"
   exec: "#b4637a"
   exec-sticky: "#907aa9"
-  no-access: "#9893a5"
-  octal: "#575279"
+  no-access: "#524d70"
+  octal: "#524d70"
 
 date:
   hour-old: "#286983"
   day-old: "#907aa9"
-  older: "#797593"
+  older: "#524d70"
 
 size:
-  none: "#9893a5"
+  none: "#524d70"
   small: "#286983"
   medium: "#907aa9"
   large: "#b4637a"
 
 inode:
   valid: "#56949f"
-  invalid: "#9893a5"
+  invalid: "#524d70"
 
 links:
   valid: "#286983"
   invalid: "#b4637a"
 
-tree-edge: "#9893a5"
+tree-edge: "#524d70"


### PR DESCRIPTION
## Summary
- ghostty の bright black (palette 8) を `#797593` → `#524d70`
- lsd の muted/no-access/group/older/size-none/inode-invalid/tree-edge を `#524d70` に統一
- Rosé Pine Dawn 下で Claude Code reasoning などの dim 表示の可読性を改善

## Test plan
- [ ] `chezmoi apply --force` 後、ghostty で dim/bright black 表示が読みやすいか確認
- [ ] `lsd` 実行時の muted 色が `#524d70` で表示されるか確認