### PR TITLE
chore(codex): TUI テーマを ansi に設定

### DIFF
--- a/private_dot_codex/config.toml
+++ b/private_dot_codex/config.toml
@@ -19,6 +19,9 @@ network_access = true
 
 suppress_unstable_features_warning = true
 
+[tui]
+theme = "ansi"
+
 [shell_environment_policy]
 inherit = "core"
 include_only = ["PATH", "HOME", "USER"]


### PR DESCRIPTION
## Summary
- `private_dot_codex/config.toml` に `[tui] theme = "ansi"` を追加
- Codex CLI の配色をターミナル側 (Rosé Pine Dawn 等) に追従させる

## Test plan
- [ ] `chezmoi apply --force` 後、`codex` 起動時に TUI がターミナル配色で表示されるか