### PR TITLE
chore(mise): GITHUB_TOKEN export を撤廃し credential_command 経由に

### DIFF
--- a/dot_zshrc
+++ b/dot_zshrc
@@ -40,12 +40,9 @@ fi
 source "$_sheldon_cache"
 unset _sheldon_cache _sheldon_toml
 
-# --- GITHUB_TOKEN (gh CLI から取得 / mise の GitHub API rate limit 回避用)
-if command -v gh &>/dev/null; then
-  export GITHUB_TOKEN="$(gh auth token 2>/dev/null)"
-fi
-
 # --- mise（shimsのみ、activate不要）
+# GitHub token は mise の credential_command で gh auth token をオンデマンド呼び出し
+# （プロセス環境への GITHUB_TOKEN 露出を回避: private_dot_config/mise/config.toml 参照）
 # PATHに既に追加済み
 
 # --- fzf

--- a/private_dot_config/mise/config.toml
+++ b/private_dot_config/mise/config.toml
@@ -32,3 +32,8 @@ pnpm = "latest"
 
 [settings]
 idiomatic_version_file_enable_tools = []
+
+[settings.github]
+# gh CLI が macOS Keychain に保存したトークンを mise が必要時のみ取得する
+# 環境変数 GITHUB_TOKEN を export しないことで他プロセスへの露出を防ぐ
+credential_command = "gh auth token"


### PR DESCRIPTION
## Summary
- `dot_zshrc` の `export GITHUB_TOKEN="$(gh auth token)"` を削除
- `private_dot_config/mise/config.toml` の `[settings.github]` に `credential_command = "gh auth token"` を追加

## Why
PR #32 で mise の GitHub API rate limit 回避のため `GITHUB_TOKEN` をシェル全体に export していたが、子プロセス (任意のコマンド) から `printenv` 等で token を読み取れる状態だった。
mise 2026.3.15 以降は `[settings.github].credential_command` で token をオンデマンド取得できるため、これを利用してプロセス環境への露出を排除する。

### セキュリティ評価
- token は mise が GitHub API を叩く瞬間だけ mise 自身のメモリに保持 → 子プロセスの env へ伝播しない
- 元 token は引き続き macOS Keychain 保管 (gh CLI 経由)
- mise は同一セッション内で per-host キャッシュするため Keychain 呼び出しは初回 1 回のみ

### 補足
gh CLI は macOS Keychain にトークンを保存するため、mise が hosts.yml を直読みするフォールバック (`gh_cli_tokens`) は機能しない。`credential_command` が唯一の自動化経路となる。

## Test plan
- [x] 新規 zsh で `echo "${GITHUB_TOKEN:-<unset>}"` が `<unset>` を返す
- [x] `mise github token` の出力が `github.com: gho_… (source: credential_command)`
- [ ] `mise install` が rate limit 警告なしで完走することを次回 install 時に確認