### PR TITLE
style(theme): Claude Code と codex を light テーマに統一

### DIFF
--- a/private_dot_claude/settings.json
+++ b/private_dot_claude/settings.json
@@ -1,5 +1,6 @@
 {
   "model": "opus",
+  "theme": "light",
   "env": {
     "CLAUDE_CODE_AUTO_CONNECT_IDE": "false",
     "CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL": "true",

--- a/private_dot_codex/config.toml
+++ b/private_dot_codex/config.toml
@@ -20,7 +20,7 @@ network_access = true
 suppress_unstable_features_warning = true
 
 [tui]
-theme = "ansi"
+theme = "light"
 
 [shell_environment_policy]
 inherit = "core"


### PR DESCRIPTION
## Summary
- `private_dot_claude/settings.json` に `"theme": "light"` を追加
- `private_dot_codex/config.toml` の `[tui] theme` を `"ansi"` → `"light"` に変更

## Why
Zed を Rosé Pine Dawn light に切り替え (#34) たのに合わせて、ターミナル系 CLI もテーマを light に揃える。Claude Code 側は元々 `theme` 未指定 (CLI デフォルト動作) だったため、light を明示する。

## Test plan
- [x] `codex doctor` で `config.toml parse ok` / `0 warn · 0 fail`
- [x] `codex exec -c approval_policy="never" "echo ok"` が成功
- [ ] Claude Code を対話起動して light テーマで表示されることを目視確認 (`-p` モードでは settings 検証が silently ignored なので、起動時に確認)