### PR TITLE
style(theme): Neovim を Rosé Pine Dawn light モードに切替

### DIFF
--- a/private_dot_config/nvim/lua/plugins/ui.lua
+++ b/private_dot_config/nvim/lua/plugins/ui.lua
@@ -11,14 +11,15 @@ return {
         italic = false,
       },
       palette = {
+        -- Kept for when switching back to the dark `rose-pine` variant.
         main = {
-          base = "#0f0f14", -- darker background
+          base = "#0f0f14",
         },
       },
     },
     config = function(_, opts)
       require("rose-pine").setup(opts)
-      vim.cmd.colorscheme("rose-pine")
+      vim.cmd.colorscheme("rose-pine-dawn")
     end,
   },
 }


### PR DESCRIPTION
## Summary
- Neovim の colorscheme を `rose-pine` (dark) から `rose-pine-dawn` (light) に切替え、Zed (#34) と表示テーマを揃える
- dark バリアントへ戻したくなった際に再利用できるよう、`palette.main.base = "#0f0f14"` の上書き設定はコメント付きで残置

## Test plan
- [ ] `nvim` を起動して背景が Rosé Pine Dawn (light) になることを確認
- [ ] `:colorscheme rose-pine` に切替えると従来通り暗い背景 (#0f0f14) になることを確認