### PR TITLE
feat(tmux): Rose Pine Dawnテーマに移行しTPMを廃止

### DIFF
--- a/dot_tmux.conf
+++ b/dot_tmux.conf
@@ -39,11 +39,9 @@ bind -n WheelUpPane if-shell -F -t = "#{mouse_any_flag}" "send-keys -M" "if -Ft=
 # Status Bar Configuration
 # ============================================================================
 
-# Status bar position and styling
+# Status bar position and layout
 set-option -g status-position top
 set-option -g status-justify centre
-set-option -g status-bg "colour238"
-set-option -g status-fg "colour255"
 
 # Update status bar every second
 set-option -g status-interval 1
@@ -96,13 +94,37 @@ bind -T copy-mode-vi Enter send -X copy-selection-and-cancel
 bind-key C-p paste-buffer
 
 # ============================================================================
-# Plugin Configuration
+# Theme: Rose Pine Dawn
 # ============================================================================
+# Palette: https://rosepinetheme.com/palette/ingredients/
+# base #faf4ed | surface #fffaf3 | overlay #f2e9e1
+# muted #9893a5 | subtle #797593 | text #575279
+# love #b4637a | gold #ea9d34 | rose #d7827e
+# pine #286983 | foam #56949f | iris #907aa9
+# hl_low #f4ede8 | hl_med #dfdad9 | hl_high #cecacd
 
-# List of plugins
-# Install plugins with: prefix + I
-# set -g @plugin 'tmux-plugins/tpm'
-# set -g @plugin 'arcticicestudio/nord-tmux'
-#
-# # Initialize TMUX plugin manager (keep this line at the very bottom)
-# run '~/.tmux/plugins/tpm/tpm'
+# Status bar
+set-option -g status-style "bg=#f2e9e1,fg=#575279"
+
+# Window list
+set-window-option -g window-status-style "fg=#797593,bg=#f2e9e1"
+set-window-option -g window-status-current-style "fg=#907aa9,bg=#f2e9e1,bold"
+set-window-option -g window-status-activity-style "fg=#b4637a,bg=#f2e9e1"
+
+# Pane borders
+set-option -g pane-border-style "fg=#9893a5"
+set-option -g pane-active-border-style "fg=#907aa9"
+
+# Copy mode selection
+set-window-option -g mode-style "bg=#dfdad9,fg=#575279"
+
+# Messages / command prompt
+set-option -g message-style "bg=#f2e9e1,fg=#575279"
+set-option -g message-command-style "bg=#f2e9e1,fg=#575279"
+
+# display-panes (prefix + q)
+set-option -g display-panes-colour "#9893a5"
+set-option -g display-panes-active-colour "#907aa9"
+
+# Clock mode
+set-window-option -g clock-mode-colour "#56949f"


### PR DESCRIPTION
## Summary
- TPM/nord-tmuxプラグインの読み込みを削除し、基本設定だけで tmux を起動するように変更
- Rose Pine Dawn 公式パレットを `dot_tmux.conf` に直接適用（status / window list / pane border / mode / message / display-panes / clock-mode を統一）
- status-right の `#(wifi) #(battery --tmux)` 表示は維持し、色のみテーマに合わせた

## Test plan
- [ ] `chezmoi apply --force ~/.tmux.conf` で反映
- [ ] `tmux source-file ~/.tmux.conf` または `tmux kill-server` 後に再起動
- [ ] status bar / pane border / window list が Rose Pine Dawn のクリーム＋紫系の配色になっていることを確認
- [ ] copy-mode で `v` 選択時のハイライトが highlight med 系になっていることを確認
- [ ] `prefix + q` の display-panes 番号色を確認