### PR TITLE
style(tmux): window list を左寄せしactiveをバッジ風に変更

### DIFF
--- a/dot_tmux.conf
+++ b/dot_tmux.conf
@@ -41,7 +41,7 @@ bind -n WheelUpPane if-shell -F -t = "#{mouse_any_flag}" "send-keys -M" "if -Ft=
 
 # Status bar position and layout
 set-option -g status-position top
-set-option -g status-justify centre
+set-option -g status-justify left
 
 # Update status bar every second
 set-option -g status-interval 1
@@ -107,8 +107,12 @@ bind-key C-p paste-buffer
 set-option -g status-style "bg=#f2e9e1,fg=#575279"
 
 # Window list
-set-window-option -g window-status-style "fg=#797593,bg=#f2e9e1"
-set-window-option -g window-status-current-style "fg=#907aa9,bg=#f2e9e1,bold"
+# inactive: text fg で読めるコントラスト
+# active: iris bg にバッジ風で一目で分かるように
+set-window-option -g window-status-style "fg=#575279,bg=#f2e9e1"
+set-window-option -g window-status-format " #I:#W#F "
+set-window-option -g window-status-current-style "fg=#fffaf3,bg=#907aa9,bold"
+set-window-option -g window-status-current-format " #I:#W#F "
 set-window-option -g window-status-activity-style "fg=#b4637a,bg=#f2e9e1"
 
 # Pane borders


### PR DESCRIPTION
## Summary
- `status-justify` を `centre` から `left` に変更（window list を左寄せ）
- inactive な window-status の fg を `subtle #797593` → `text #575279` に変更し読めるコントラストを確保
- active な window-status を `fg=#fffaf3,bg=#907aa9,bold`（surface on iris）のバッジ風に変更し一目で識別可能に
- `window-status-format` / `window-status-current-format` で前後にスペースを追加

## Test plan
- [ ] `chezmoi apply --force ~/.tmux.conf` で反映
- [ ] `tmux source-file ~/.tmux.conf` でリロード
- [ ] window list が左寄せになっていることを確認
- [ ] active window が紫バッジで際立っていることを確認
- [ ] inactive window が読みやすい濃さになっていることを確認