### PR TITLE
docs(readme): AI Integration セクションを削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,6 @@ git clone https://github.com/daikichiba9511/dotfiles.git ~/dotfiles
 | **nvim-treesitter** | Syntax highlighting |
 | **fzf-lua + snacks.nvim** | Fuzzy finder & utilities |
 
-### AI Integration
-
-| Tool | Description |
-|------|-------------|
-| **claude-code.nvim** | Claude Code CLI integration |
-| **copilot.lua** | GitHub Copilot |
-| **Avante** | AI assistant |
-
 ### Terminal & Shell
 
 | Tool | Description |
@@ -131,17 +123,6 @@ git clone https://github.com/daikichiba9511/dotfiles.git ~/dotfiles
 | `Cmd+Shift + 1-9` | Move to workspace |
 | `Alt + f` | Fullscreen |
 | `Alt + t` | Toggle float |
-
-</details>
-
-<details>
-<summary><strong>Neovim (Claude Code)</strong></summary>
-
-| Key | Action |
-|-----|--------|
-| `<leader>cc` | Toggle Claude Code |
-| `<leader>cs` | Send selection to Claude |
-| `<leader>cf` | Focus Claude Code |
 
 </details>
 


### PR DESCRIPTION
## Summary
- AI Integration セクションを削除（claude-code.nvim / copilot.lua / Avante）
- Keybindings の Neovim (Claude Code) セクションを削除
- nvim 設定からも該当プラグインは既に消えており、README だけ古い情報が残っていた

## Test plan
- [ ] GitHub 上で README のプレビューが崩れていないことを確認
- [ ] Structure 以下のセクションが正しく続いていることを確認