### PR TITLE
feat(nvim): markdown の lint/lsp 環境を整備

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,6 +26,9 @@
           gh
           neovim-unwrapped
           ghq
+          # markdown LSP/lint CLIs (consumed by nvim efm-langserver / nvim-lint)
+          markdownlint-cli2
+          textlint
         ];
       in
       {

--- a/private_dot_config/nvim/after/lsp/efm.lua
+++ b/private_dot_config/nvim/after/lsp/efm.lua
@@ -1,0 +1,24 @@
+-- efm-langserver: wraps CLI linters as LSP diagnostics for markdown (textlint)
+return {
+  filetypes = { "markdown" },
+  root_markers = { ".textlintrc", ".textlintrc.json", "package.json", ".git" },
+  init_options = {
+    documentFormatting = false,
+    documentRangeFormatting = false,
+    codeAction = false,
+    hover = false,
+    completion = false,
+  },
+  settings = {
+    languages = {
+      markdown = {
+        {
+          lintCommand = "textlint --no-color --format compact --stdin --stdin-filename ${INPUT}",
+          lintStdin = true,
+          lintFormats = { "%f:line %l:column %c: %m" },
+          rootMarkers = { ".textlintrc", ".textlintrc.json", "package.json" },
+        },
+      },
+    },
+  },
+}

--- a/private_dot_config/nvim/lua/lsp/init.lua
+++ b/private_dot_config/nvim/lua/lsp/init.lua
@@ -17,6 +17,9 @@ local ls_names = {
   "sqls",
   -- cpp
   "clangd",
+  -- markdown
+  "marksman",
+  "efm",
 }
 
 -- Setup Mason-lspconfig

--- a/private_dot_config/nvim/lua/plugins/lint.lua
+++ b/private_dot_config/nvim/lua/plugins/lint.lua
@@ -1,0 +1,19 @@
+-- Diagnostic linters (non-LSP CLIs surfaced via vim.diagnostic)
+return {
+  {
+    "mfussenegger/nvim-lint",
+    event = { "BufReadPost", "BufNewFile" },
+    config = function()
+      local lint = require("lint")
+      lint.linters_by_ft = {
+        markdown = { "markdownlint-cli2" },
+      }
+      vim.api.nvim_create_autocmd({ "BufWritePost", "BufReadPost", "InsertLeave" }, {
+        group = vim.api.nvim_create_augroup("nvim-lint", { clear = true }),
+        callback = function()
+          require("lint").try_lint()
+        end,
+      })
+    end,
+  },
+}


### PR DESCRIPTION
## Summary
markdown ファイル編集時の lint/lsp 体験を整備。

- `flake.nix` に `markdownlint-cli2` / `textlint` を追加（後述の nvim 連携から CLI として利用）
- `nvim/lua/lsp/init.lua` の `ls_names` に `marksman` / `efm` を追加
- `nvim/after/lsp/efm.lua` を新規追加: efm-langserver で textlint を呼び LSP 診断化
- `nvim/lua/plugins/lint.lua` を新規追加: nvim-lint で markdownlint-cli2 を保存時に実行

## Notes
- efm 設定は `documentFormatting`/`hover`/`completion` を無効化し、純粋に lint diagnostic のみ提供
- nvim-lint はバッファ保存・読み込み・InsertLeave で発火

## Test plan
- [ ] `nix develop` で markdownlint-cli2 / textlint が PATH に入ることを確認
- [ ] Neovim で markdown を開いた時に marksman / efm が起動することを確認 (`:LspInfo`)
- [ ] textlint のルール違反が diagnostic に出ることを確認
- [ ] 保存時に markdownlint-cli2 の警告が表示されることを確認