### PR TITLE
refactor(zsh): ghq+fzf 周りを整理し gcd コマンドを追加

### DIFF
--- a/dot_zshrc
+++ b/dot_zshrc
@@ -76,19 +76,33 @@ if command -v fzf &>/dev/null; then
   zle -N fzf-history-widget
   bindkey '^R' fzf-history-widget
 
-  # ghq + fzf (Ctrl+G)
-  ghq-fzf-widget() {
-    local repo
-    repo=$(ghq list | fzf --preview "bat --style=numbers --color=always $(ghq root)/{}/README.md 2>/dev/null || ls -la $(ghq root)/{}")
-    if [[ -n "$repo" ]]; then
-      BUFFER="cd $(ghq root)/${repo}"
-      zle accept-line
-    else
-      zle reset-prompt
-    fi
-  }
-  zle -N ghq-fzf-widget
-  bindkey '^G' ghq-fzf-widget
+  # ghq + fzf
+  if command -v ghq &>/dev/null; then
+    _ghq-fzf-select() {
+      ghq list | fzf --preview "bat --style=numbers --color=always $(ghq root)/{}/README.md 2>/dev/null || ls -la $(ghq root)/{}"
+    }
+
+    # コマンド版: ghqリポジトリをfuzzy検索してcd
+    gcd() {
+      local repo
+      repo=$(_ghq-fzf-select)
+      [[ -n "$repo" ]] && cd "$(ghq root)/${repo}"
+    }
+
+    # Widget版 (Ctrl+G): コマンドラインに反映してaccept-line（履歴に残す）
+    ghq-fzf-widget() {
+      local repo
+      repo=$(_ghq-fzf-select)
+      if [[ -n "$repo" ]]; then
+        BUFFER="cd $(ghq root)/${repo}"
+        zle accept-line
+      else
+        zle reset-prompt
+      fi
+    }
+    zle -N ghq-fzf-widget
+    bindkey '^G' ghq-fzf-widget
+  fi
 fi
 
 # --- エイリアス


### PR DESCRIPTION
## Summary
- `ghq` コマンドの存在チェックを追加（未インストール環境で起動時に warnings/errors を出さない）
- 共通関数 `_ghq-fzf-select` を導入し、fzf preview ロジックを 1箇所に集約
- `gcd` 関数（コマンド版）を新規追加: シェルから `gcd` で ghq リポジトリを fuzzy 選択して cd
- 既存の `Ctrl+G` widget も同じ共通関数経由に統一

## Test plan
- [ ] `source ~/.zshrc` で再読み込みしてエラーが出ないことを確認
- [ ] `gcd` コマンドで fzf 起動 → 選択 → cd できることを確認
- [ ] `Ctrl+G` キーで widget が動作し、選択結果が履歴に残ることを確認
- [ ] ghq 未インストール環境（または `unalias / unset` で疑似）で zshrc 読み込みが失敗しないことを確認