### PR TITLE
feat(codex): TUI のステータスラインを設定

### DIFF
--- a/private_dot_codex/private_config.toml
+++ b/private_dot_codex/private_config.toml
@@ -22,6 +22,14 @@ suppress_unstable_features_warning = true
 
 [tui]
 theme = "github"
+status_line = [
+  "model-with-reasoning",
+  "current-dir",
+  "git-branch",
+  "context-remaining",
+  "five-hour-limit",
+  "weekly-limit",
+]
 
 [shell_environment_policy]
 inherit = "core"


### PR DESCRIPTION
## Summary
Codex CLI の TUI ステータスラインに表示する項目を `[tui].status_line` で明示。

表示項目:
- `model-with-reasoning`
- `current-dir`
- `git-branch`
- `context-remaining`
- `five-hour-limit`
- `weekly-limit`

## Test plan
- [ ] `chezmoi apply --force ~/.codex/config.toml` で反映
- [ ] Codex CLI 起動時のステータスラインに上記項目が出ることを確認