### PR TITLE
feat(hunk): hunk diff viewer を導入し git/lazygit/nvim と統合

### DIFF
--- a/dot_gitconfig
+++ b/dot_gitconfig
@@ -4,7 +4,7 @@
   signingkey = E8E94E2A3C8A9567
 [core]
   editor = nvim
-  pager = delta
+  pager = hunk pager
   excludesfile = ~/.config/git/ignore
 
 [alias]
@@ -25,11 +25,6 @@
   directory = /workspace/working
 [interactive]
   diffFilter = delta --color-only
-[delta]
-  line-numbers = true
-  dark = false
-[delta "line-number"]
-  line-numbers-left-style = cyan
 [merge]
   conflictstyle = diff3
   tool = vimdiff

--- a/flake.nix
+++ b/flake.nix
@@ -4,13 +4,20 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
+    hunk = {
+      url = "github:modem-dev/hunk";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
+  outputs = { self, nixpkgs, flake-utils, hunk }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
-        tools = with pkgs; [
+        hunk-pkg = hunk.packages.${system}.default;
+        tools = [
+          hunk-pkg
+        ] ++ (with pkgs; [
           zsh
           jq
           tree-sitter
@@ -29,7 +36,7 @@
           # markdown LSP/lint CLIs (consumed by nvim efm-langserver / nvim-lint)
           markdownlint-cli2
           textlint
-        ];
+        ]);
       in
       {
         packages.default = pkgs.buildEnv {

--- a/private_dot_config/hunk/config.toml
+++ b/private_dot_config/hunk/config.toml
@@ -1,0 +1,6 @@
+theme = "graphite"
+mode = "auto"
+vcs = "git"
+line_numbers = true
+wrap_lines = false
+transparent_background = true

--- a/private_dot_config/lazygit/config.yml
+++ b/private_dot_config/lazygit/config.yml
@@ -1,0 +1,7 @@
+gui:
+  nerdFontsVersion: "3"
+
+git:
+  paging:
+    colorArg: always
+    pager: hunk pager

--- a/private_dot_config/mise/config.toml
+++ b/private_dot_config/mise/config.toml
@@ -22,6 +22,7 @@ gh = "latest"
 "aqua:neovim/neovim" = "0.12"
 usage = "latest"
 ghq = "latest"
+"npm:hunkdiff" = "latest"
 
 aws-cli = "latest"
 terraform = "latest"

--- a/private_dot_config/nvim/lua/plugins/snacks.lua
+++ b/private_dot_config/nvim/lua/plugins/snacks.lua
@@ -460,6 +460,13 @@ return {
         desc = "Lazygit",
       },
       {
+        "<leader>gH",
+        function()
+          Snacks.terminal("hunk")
+        end,
+        desc = "Hunk (diff viewer)",
+      },
+      {
         "<leader>un",
         function()
           Snacks.notifier.hide()


### PR DESCRIPTION
## Summary
- delta に代わり [modem-dev/hunk](https://github.com/modem-dev/hunk) をデフォルト diff pager に設定
- nix flake input + mise (`npm:hunkdiff`) の両経路でインストール可能に
- lazygit の pager を hunk に設定 (`private_dot_config/lazygit/config.yml` 新規作成)
- neovim から `<leader>gH` で hunk を Snacks.terminal で起動可能に
- `interactive.diffFilter` は delta を維持（`git add -p` 用）

## Test plan
- [ ] `nix flake update hunk && nix build` でビルド通ること
- [ ] `mise install` で hunkdiff がインストールされること
- [ ] `git diff` で hunk の TUI が表示されること
- [ ] lazygit 内の diff view で hunk が使われること
- [ ] neovim で `<leader>gH` が動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)