### PR TITLE
chore: VS Code ターミナル分割キーバインドと gitignore 更新

### DIFF
--- a/private_Library/private_Application Support/private_Code - Insiders/User/keybindings.json
+++ b/private_Library/private_Application Support/private_Code - Insiders/User/keybindings.json
@@ -14,6 +14,7 @@
   //
   // ### Editor & Window Navigation
   // - Ctrl+w h/j/k/l           : Navigate between split windows (Vim-style)
+  // - Ctrl+w a                 : Split right + below, open terminal editors in both new groups
   // - Ctrl+j/k                 : Navigate between editor tabs
   // - Ctrl+x                   : Close active editor
   //
@@ -650,5 +651,27 @@
   {
     "key": "alt+s",
     "command": "workbench.action.switchWindow",
+  },
+
+  // Split editor right + below, open terminal editors in both new groups
+  {
+    "key": "ctrl+w a",
+    "command": "runCommands",
+    "args": {
+      "commands": [
+        {
+          "command": "workbench.action.newGroupRight",
+        },
+        {
+          "command": "workbench.action.createTerminalEditor",
+        },
+        {
+          "command": "workbench.action.newGroupBelow",
+        },
+        {
+          "command": "workbench.action.createTerminalEditor",
+        },
+      ],
+    },
   },
 ]

--- a/private_dot_config/git/ignore
+++ b/private_dot_config/git/ignore
@@ -62,3 +62,8 @@ Temporary Items
 *.pfx
 *secret*
 credentials*
+
+# =====================
+# Claude Code working notes
+# =====================
+tasks/


### PR DESCRIPTION
## Summary
- VS Code Insiders に `Ctrl+w a` キーバインドを追加（右+下分割でターミナルエディタを2つ開く）
- グローバル gitignore に `tasks/` を追加（Claude Code 作業ファイルの除外）

## Test plan
- [ ] VS Code Insiders で `Ctrl+w a` が期待通り動作すること
- [ ] `tasks/` ディレクトリが git tracking から除外されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)