### PR TITLE
[codex] ML実験コード方針を明文化

### DIFF
--- a/private_dot_claude/rules/coding-style.md
+++ b/private_dot_claude/rules/coding-style.md
@@ -3,6 +3,9 @@
 ## Comments
 - Express "what" through code. Comments explain "why" only.
 - If logic needs naming and explanation, extract into a function.
+- Add comments for non-obvious invariants, experimental assumptions, leakage prevention, reproducibility constraints, and intentional deviations from the straightforward implementation.
+- Do not add comments that merely restate the code, narrate each step, or become stale when names change.
+- When changing code, update or remove nearby comments in the same edit.
 
 ## Connascence
 - Multiple return values: use structs (dataclass, etc.) instead of positional tuples.

--- a/private_dot_claude/rules/ml-experiments.md
+++ b/private_dot_claude/rules/ml-experiments.md
@@ -15,9 +15,15 @@ EDA > hypothesis > experiment > logging > analysis > next hypothesis. Read relat
 
 ## Error Handling
 - Crash immediately on invalid state (Fail Fast). Let errors propagate naturally.
+- Do not use fallback behavior for missing configs, artifacts, columns, features, checkpoints, dependencies, or unsupported modes.
+- Do not silently continue with guessed defaults, empty results, skipped steps, cached alternatives, or "best effort" behavior.
+- If a branch is optional, model it explicitly in config and raise for unsupported combinations.
 
 ## Config
 - Centralize in a `Config` dataclass. Map to per-module dataclasses for arguments.
+- Do not use raw `dict` for experiment config, feature definitions, model parameters, dataset schema, or metric settings.
+- Load YAML/JSON/TOML into typed dataclasses immediately at the boundary.
+- Missing or unknown config fields should raise during construction or validation.
 
 ## Train/Inference Consistency
 - Extract preprocessing to a shared module. Use the same function for train and inference.

--- a/private_dot_claude/rules/python.md
+++ b/private_dot_claude/rules/python.md
@@ -13,6 +13,9 @@ paths:
 - Boundary validation: pydantic with `frozen=True`
 - Domain models: `dataclasses.dataclass(frozen=True)`
 - Convert via `to_<domain_model>()` after validation
+- Prefer dataclasses or pydantic models over raw `dict` for structured data.
+- Use `Mapping` only for generic read-only inputs or external boundaries, then convert to typed models.
+- Avoid fallback defaults for invalid or missing data; raise explicit errors instead.
 
 ## CLI (tyro)
 - List args use space separation: `--items a b c`

--- a/private_dot_codex/skills/ml-cleanup/SKILL.md
+++ b/private_dot_codex/skills/ml-cleanup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ml-cleanup
-description: Clean up ML experiment code, reduce bloat, extract shared logic
+description: Clean up ML experiment code after exploration has stabilized. Use when the user explicitly asks to remove dead code, reduce copy-paste remnants, or extract stable shared logic. Do not use to prematurely abstract active exploratory code.
 allowed-tools: Read, Edit, Write, Glob, Grep, Bash(run tests:*)
 ---
 
@@ -11,6 +11,13 @@ You are an ML experiment code cleaner. Analyze and clean up experiment code to r
 `/ml-cleanup <exp_dir>` - e.g., `/ml-cleanup exp003` or `/ml-cleanup src/exp/exp003`
 
 ## Workflow
+
+### 0. Confirm Exploration State
+
+- If the experiment is still in active exploration, do not extract functions, classes, or shared modules merely for readability.
+- Keep tentative concepts inline until they have proven stable.
+- Preserve why-comments that explain hypotheses, assumptions, leakage prevention, reproducibility constraints, and intentional deviations.
+- Prefer destructive simplification over adding compatibility paths, bypasses, or fallback routes.
 
 ### 1. Analyze Target Experiment
 
@@ -33,7 +40,8 @@ You are an ML experiment code cleaner. Analyze and clean up experiment code to r
 
 **Duplication:**
 - Logic duplicated within the experiment
-- Logic that should be in `src/exp/common/` or `src/lib/`
+- Stable logic that has proven reusable enough to move to `src/exp/common/` or `src/lib/`
+- Algorithmic or data-structure complexity that should be hidden behind a function boundary
 
 ### 3. Suggest Improvements
 
@@ -87,6 +95,10 @@ For each issue:
 - Don't remove code that might be used dynamically
 - Preserve experiment reproducibility
 - Ask before making large changes
+- Do not optimize for production cleanliness while exploration is still unfolding
+- Do not replace simple inline exploratory code with abstractions unless the user requested it or the concept is stable
+- Do not introduce fallback behavior while cleaning up; fail fast and keep the control flow simple
+- Keep comments that explain why an experimental block exists, and remove comments that only restate what the code does
 
 ## Target Directory
 

--- a/private_dot_codex/skills/ml-docs/SKILL.md
+++ b/private_dot_codex/skills/ml-docs/SKILL.md
@@ -139,10 +139,12 @@ Post-experiment documentation update. Covers both pre-experiment design and post
 ### Step 0: Pre-Experiment Design (if not already logged)
 
 Before running an experiment, ensure `docs/logs.md` has an `[EXPERIMENT]` entry containing:
+- **Date**: Experiment date
 - **Baseline**: What we are comparing against
 - **Changes**: Exactly what differs from baseline
 - **Hypothesis**: What we expect and why
 - **Considerations**: Potential issues, edge cases, interactions
+- **Code Evidence**: Files, functions, commands, commits, or config paths that implement the change
 - **Result Scenarios**: Pre-registered interpretations for each outcome (improve / marginal / no change / degrade)
 
 If this entry is missing, create it FIRST by asking the user.
@@ -151,8 +153,10 @@ If this entry is missing, create it FIRST by asking the user.
 
 Append experiment results to `docs/logs.md`:
 - `[RESULT]` entry: raw metrics, observations, and **which pre-registered scenario matched**
-- `[ANALYSIS]` entry: interpretation, implications, next hypotheses
+- `[ANALYSIS]` entry: interpretation, implications, next hypotheses, and why the change worked or did not work
 - Include raw numbers, not just summary
+- Write experiment notes in Japanese unless the user requests otherwise
+- Include enough implementation evidence that the experiment can be understood and explained from the notes
 
 ### Step 2: Update Evidence Ledger
 
@@ -189,5 +193,6 @@ When operating on documents, follow these principles:
 - **Dependency**: Track which decisions depend on which evidence IDs
 - **Bias**: Phase 2 of strategy MUST NOT access prior results. This is non-negotiable
 - **Input design over reasoning**: The quality of output depends more on what context is loaded than on reasoning instructions
+- **Learning over polish**: For exploratory code, preserve what was tried, what worked, what failed, and why; do not rewrite history into a clean story
 
 $ARGUMENTS

--- a/private_dot_codex/skills/ml-docs/references/layer-formats.md
+++ b/private_dot_codex/skills/ml-docs/references/layer-formats.md
@@ -38,6 +38,9 @@ Use the tag-specific templates below. All entries share a common header.
 ### Hypothesis
 [What we expect to happen and why]
 
+### Code Evidence
+[Files, functions, commands, commits, configs, or notebook cells that implement the change]
+
 ### Considerations
 [Potential issues, edge cases, interactions with other components, things to watch for]
 
@@ -60,6 +63,9 @@ Use the tag-specific templates below. All entries share a common header.
 ### Observations
 [Unexpected behaviors, training dynamics, error patterns, etc.]
 
+### Code Evidence
+[Exact run command, config path, commit, output file, or log path used for this result]
+
 ### Matched Scenario
 [Which pre-registered scenario from the EXPERIMENT entry matches, and whether the pre-registered interpretation still holds]
 ```
@@ -73,7 +79,7 @@ Use the tag-specific templates below. All entries share a common header.
 [What happened in one sentence]
 
 ### Interpretation
-[Why we think this happened. Cite evidence IDs where possible]
+[Why we think this happened. Explain what worked, what did not work, and why. Cite evidence IDs where possible]
 
 ### Implications
 [What this means for our overall approach]
@@ -115,9 +121,12 @@ Use the tag-specific templates below. All entries share a common header.
 ### Rules
 
 - Append only, never edit past entries
-- **Every experiment MUST have an [EXPERIMENT] entry BEFORE execution** with baseline, changes, hypothesis, considerations, and pre-registered result scenarios
+- **Every experiment MUST have an [EXPERIMENT] entry BEFORE execution** with baseline, changes, hypothesis, code evidence, considerations, and pre-registered result scenarios
 - **Every [RESULT] entry MUST reference which scenario matched** from the corresponding [EXPERIMENT] entry
 - Include raw numbers, not just interpretations
+- Write experiment notes in Japanese unless the user requests otherwise
+- Include date, hypothesis, what was done, results, analysis, and code-backed evidence
+- Preserve what was tried, what worked, what did not work, and why
 - Record failed attempts and dead ends
 - Link to related entries by date/tag when relevant
 

--- a/private_dot_codex/skills/ml-iterate/SKILL.md
+++ b/private_dot_codex/skills/ml-iterate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ml-iterate
-description: ML experiment iteration workflow - hypothesis, experiment, analysis cycle
+description: ML experiment iteration workflow for hypothesis, exploratory experiment coding, result logging, and analysis. Use when designing, writing, running, or analyzing ML/Kaggle experiment code where exploration speed and learning what works matter more than production cleanliness.
 allowed-tools: Read, Edit, Write, Glob, Grep, Bash(run experiment:*), Bash(python:*)
 ---
 
@@ -50,12 +50,50 @@ Ask clarifying questions:
 - What metrics will we track?
 - What's the minimal experiment to test the hypothesis?
 
-### Phase 4: README.md Creation/Update
+### Phase 4: Exploratory Coding
+
+When writing ML or other exploratory experiment code, optimize for exploration width, iteration speed, and clear experimental meaning.
+Do not prematurely turn tentative ideas into stable abstractions.
+
+**Default stance:**
+
+- Unless explicitly instructed, do not extract helper functions, classes, or shared modules merely for readability or reuse.
+- It is acceptable to keep an exploratory run in one script or even one large function while the concept is still unstable.
+- Still preserve meaning-unit granularity: separate stages with clear local variables, section comments, and execution order.
+- Code may be somewhat messy if that keeps the experiment direct, but the state should stay simple enough that the impact of edits is easy to understand.
+- Prefer destructive changes over adding bypasses, alternate routes, compatibility paths, or fallback branches.
+
+**Data and failure handling:**
+
+- Use dataclasses or typed structures for config, feature definitions, model parameters, dataset schema, metrics, and experiment records.
+- Avoid raw `dict` for structured data because `get()` and optional key access delay failure and can bend meaning.
+- Prefer immutable data structures where practical.
+- Fail fast on missing data, invalid state, unsupported modes, and unexpected schema.
+- Do not add fallback behavior, guessed defaults, skipped steps, or best-effort continuation unless the user explicitly asks.
+
+**Performance:**
+
+- Default to code designs that are not slow.
+- Do not choose obviously slow code just because it looks more readable.
+- Preserve enough readability to keep the experiment understandable, but prefer faster vectorized, batched, indexed, cached, or precomputed forms when they are straightforward.
+- When a data structure or algorithm materially lowers complexity, define a function boundary around that complexity so the implementation detail does not leak into the experiment body.
+
+**Comments as future extraction markers:**
+
+- Add comments that explain why a block exists: hypothesis context, experimental assumption, leakage prevention, reproducibility constraint, metric interpretation, or an intentional deviation from the obvious implementation.
+- These comments should be usable later as the reason a function exists if the concept stabilizes.
+- Do not comment what the code mechanically does.
+- If a block needs a name and the concept is stable, then extraction may be appropriate; if the concept is still being explored, keep the block inline with a clear why-comment.
+
+### Phase 5: README.md Creation/Update
 
 Create or update `src/exp/{exp_dir}/README.md`:
 
 ```markdown
 # {exp_dir}: [Experiment Title]
+
+## Date
+[YYYY-MM-DD]
 
 ## Background / Related Experiments
 - {related_exp}: [Key learnings from that experiment]
@@ -67,18 +105,22 @@ Create or update `src/exp/{exp_dir}/README.md`:
 - **Baseline**: ...
 - **Change**: ...
 - **Metrics**: ...
+- **Code Evidence**: [Files/functions/commit/command that implement the change]
 
 ## Results
-[To be filled after experiment]
+[Raw numbers, logs, tables, and comparison to baseline]
 
 ## Analysis / Discussion
-[To be filled after experiment]
+[Why the result happened, what worked, what did not work, and what remains uncertain]
 
 ## Next Actions
 [To be filled after analysis]
 ```
 
-### Phase 5: Post-Experiment (when results are available)
+Write experiment notes in Japanese unless the user requests otherwise.
+Include enough code-backed evidence that another reader can understand and explain the experiment without guessing.
+
+### Phase 6: Post-Experiment (when results are available)
 
 1. **Log results** in README.md
 2. **Analyze**: What do the results tell us?
@@ -107,6 +149,10 @@ Create or update `src/exp/{exp_dir}/README.md`:
 - Document everything, even negative results
 - Link experiments together through README references
 - Ask before assuming - clarify intent
+- In exploratory code, the goal is learning and achieving the experiment objective, not making production-quality structure
+- Track what worked, what did not work, and why
+- Avoid premature abstraction during exploration; extract only for stable concepts or to hide algorithmic complexity
+- Prefer fail-fast, typed, immutable structures over raw dictionaries and fallback paths
 
 ## Current Experiment
 


### PR DESCRIPTION
## Summary

- Clarify Claude rules for ML experiment code: prefer typed dataclasses over raw dictionaries, fail fast, and avoid fallback behavior.
- Update Codex ML skills to preserve exploration speed, avoid premature abstraction, and keep meaning-unit comments inline while concepts are unstable.
- Expand ML documentation templates so experiment notes capture date, hypothesis, implementation evidence, results, and analysis in Japanese.

## Validation

- Ran `git diff --check` before staging.
- Ran `git diff --cached --check` before commit.
- Confirmed `AGENTS.md` remained untracked and excluded from the commit.